### PR TITLE
Tuning docker network mode: host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,6 @@ version: "3.5"
 volumes:
   postgres:
 
-networks:
-  default:
-    driver: bridge
-
 services:
   database:
     image: postgres:latest
@@ -20,78 +16,48 @@ services:
       test: ["CMD-SHELL", "pg_isready -U dev -d rinha"]
       interval: 5s
       timeout: 5s
-    ports:
-      - "5432:5432"
-    expose:
-      - "5432"
+    network_mode: host
     deploy:
       resources:
         limits:
-          cpus: "0.7"
+          cpus: "0.8"
           memory: "1.5GB"
     volumes:
       - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql
-      - postgres:/var/lib/postgresql/data
 
   api1:
-    image: insalubre/rinhabackend:latest
+    # image: insalubre/rinhabackend:latest
+    build: .
     hostname: api1
+    environment:
+      PORT: 8080
     restart: unless-stopped
     depends_on:
       database:
         condition: service_healthy
+    network_mode: host
     deploy:
       resources:
         limits:
-          cpus: "0.15"
-          memory: "0.25GB"
-    expose:
-      - "8080"
+          cpus: "0.25"
+          memory: "0.5GB"
 
   api2:
-    image: insalubre/rinhabackend:latest
+    # image: insalubre/rinhabackend:latest
+    build: .
     hostname: api2
+    environment:
+      PORT: 8081
     restart: unless-stopped
     depends_on:
       database:
         condition: service_healthy
+    network_mode: host
     deploy:
       resources:
         limits:
-          cpus: "0.15"
-          memory: "0.25GB"
-    expose:
-      - "8080"
-
-  api3:
-    image: insalubre/rinhabackend:latest
-    hostname: api3
-    restart: unless-stopped
-    depends_on:
-      database:
-        condition: service_healthy
-    deploy:
-      resources:
-        limits:
-          cpus: "0.15"
-          memory: "0.25GB"
-    expose:
-      - "8080"
-
-  api4:
-    image: insalubre/rinhabackend:latest
-    hostname: api4
-    restart: unless-stopped
-    depends_on:
-      database:
-        condition: service_healthy
-    deploy:
-      resources:
-        limits:
-          cpus: "0.15"
-          memory: "0.25GB"
-    expose:
-      - "8080"
+          cpus: "0.25"
+          memory: "0.5GB"
 
   nginx:
     image: nginx
@@ -101,8 +67,7 @@ services:
     depends_on:
       - api1
       - api2
-    ports:
-      - "9999:9999"
+    network_mode: host
     deploy:
       resources:
         limits:

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,10 +9,8 @@ http {
         keepalive 256;
         keepalive_requests 10000;
 
-        server api1:8080;
-        server api2:8080;
-        server api3:8080;
-        server api4:8080;
+        server localhost:8080;
+        server localhost:8081;
     }
     server {
         listen 9999;

--- a/src/main.v
+++ b/src/main.v
@@ -6,9 +6,10 @@ import net.http
 import db.pg
 import net.urllib
 import time
+import os
 
 const (
-	port = 8080
+	port = os.getenv("PORT").int()
 )
 
 struct App {
@@ -175,7 +176,7 @@ fn main() {
 
 	mut app := &App{
 		db: pg.connect(pg.Config{
-			host: 'database'
+			host: 'localhost'
 			port: 5432
 			user: 'dev'
 			password: 'dev'


### PR DESCRIPTION
changing docker compose to network mode host in all containers to overcome the bridge overhead that caps the stress test. now going to over 46k. also doing a small tweak in the source code to accept different http ports as in host mode each app instance must be in a different port